### PR TITLE
Fix missing asyncio import in OCR tool

### DIFF
--- a/mcp-server/mistral_ocr_tool.py
+++ b/mcp-server/mistral_ocr_tool.py
@@ -4,6 +4,7 @@ Mistral OCR MCP Tool Implementation
 
 import os
 import base64
+import asyncio
 from typing import Optional
 from mistralai import Mistral
 import logging


### PR DESCRIPTION
## Summary
- add missing asyncio import to Mistral OCR tool module

## Testing
- `python -m py_compile mcp-server/mistral_ocr_tool.py`
- `python -m compileall backend mcp-server`

------
https://chatgpt.com/codex/tasks/task_e_684acd4ebc5883279a2258ad4882ee0c