### PR TITLE
Improve Google Drive markdown search

### DIFF
--- a/backend/rag_pipeline.py
+++ b/backend/rag_pipeline.py
@@ -133,7 +133,7 @@ class RAGPipeline:
                         }
                         gdrive_request = {
                             "hierarchical_keywords": clean_hierarchical,
-                            "file_types": ["document", "sheet", "pdf"],
+                            "file_types": ["document", "sheet", "pdf", "markdown"],
                             "max_results": 100
                         }
                         logger.info(f"Using hierarchical keywords for Google Drive search")
@@ -142,7 +142,7 @@ class RAGPipeline:
                         # 従来のキーワード検索
                         gdrive_request = {
                             "keywords": keywords,
-                            "file_types": ["document", "sheet", "pdf"],
+                            "file_types": ["document", "sheet", "pdf", "markdown"],
                             "max_results": 100
                         }
                         logger.info(f"Using simple keywords for Google Drive search: {keywords[:3]}...")


### PR DESCRIPTION
## Summary
- include `markdown` file type when building Google Drive request
- support multiple MIME types for markdown files
- filter by `.md` name when searching for markdown documents

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ad7f977248327845691b89e81f477