### PR TITLE
Enable remote Chrome history updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ curl http://localhost:8000/health  # Backend API
 - **API Docs**: http://localhost:8000/docs
 - **MCP Server**: http://localhost:8501
 
+### Chrome Extension Remote Usage
+
+1. Set the MCP server URL inside the extension. In the browser console run:
+
+```javascript
+chrome.storage.local.set({ serverUrl: 'https://your-server.example' });
+```
+
+2. Reload the extension. When using a remote HTTPS server, ensure the server
+   certificate is valid and that CORS is configured to allow the extension origin.
+
 ## 🏗️ Architecture
 
 - **Frontend**: Next.js 14 with TypeScript and Tailwind CSS

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -47,6 +47,17 @@ Chrome の履歴データに直接 SQLite ファイルアクセスするので�
 - `storage`: 設定の保存
 - `activeTab`: 現在のタブへのアクセス
 
+### 3. サーバーURLの設定
+
+リモートの MCP サーバーを利用する場合は、ブラウザのコンソールで以下を実行して
+サーバー URL を保存します。
+
+```javascript
+chrome.storage.local.set({ serverUrl: 'https://your-server.example' });
+```
+
+HTTPS サーバーを指定する場合は、証明書が有効であることを確認してください。
+
 ## 🚀 使用方法
 
 ### JavaScript API
@@ -68,6 +79,9 @@ const recent = await window.ExtendYourMemoryBridge.getRecentHistory({
   hours: 24,          // 取得対象時間
   maxResults: 100     // 最大結果数
 });
+
+// 履歴データの送信を明示的にトリガー
+await window.ExtendYourMemoryBridge.refreshHistory();
 
 // 拡張機能の利用可能性チェック
 const available = window.ExtendYourMemoryBridge.isExtensionAvailable();
@@ -159,9 +173,9 @@ MCP サーバーは以下の方法で拡張機能と連携します：
 
 ### Current Limitations
 
-1. **Local Development Only**: 現在は localhost のみサポート
-2. **Manual Installation**: Chrome Web Store への公開は未実装
-3. **HTTP Only**: HTTPS サポートは追加実装が必要
+1. **Manual Installation**: Chrome Web Store への公開は未実装
+2. **Remote Usage**: サーバー URL を `chrome.storage.local` に設定することでリモート環境でも利用可能
+3. **HTTPS Recommended**: セキュアな通信のため公開環境では HTTPS を使用
 
 ### Future Enhancements
 
@@ -210,6 +224,7 @@ chrome://extensions/ → 拡張機能詳細 → background page を検査
 - `searchHistory(keywords, options)`: キーワードベースの履歴検索
 - `getRecentHistory(options)`: 最近の履歴取得
 - `getVisitDetails(url)`: 特定URLの詳細情報取得
+- `refreshHistory()`: 履歴データをサーバーへ即時送信
 
 ---
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -128,6 +128,16 @@ export default function Home() {
     setResult(null)
     setError(null)
 
+    // Ask Chrome extension to send latest history to the server if available
+    try {
+      const bridge: any = (window as any).ExtendYourMemoryBridge
+      if (bridge && bridge.isExtensionAvailable()) {
+        await bridge.refreshHistory().catch(() => {})
+      }
+    } catch (e) {
+      console.debug('Extension refresh failed', e)
+    }
+
     try {
       const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
       const wsUrl = apiUrl.replace('http', 'ws') + '/ws/search'

--- a/mcp-server/server_fastapi.py
+++ b/mcp-server/server_fastapi.py
@@ -181,6 +181,23 @@ async def get_recent_chrome_history_endpoint(
         logger.error(f"Error getting recent Chrome history: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
+class ExtensionCommand(BaseModel):
+    """Command request for the Chrome extension"""
+    action: str
+    params: Optional[Dict[str, Any]] = None
+
+
+@app.post("/api/chrome/extension")
+async def chrome_extension_command(command: ExtensionCommand):
+    """Handle requests directed to the Chrome extension"""
+    try:
+        logger.info(f"Extension command: {command.action}")
+        # Placeholder implementation - extension polls this endpoint
+        return {"success": True, "received": command.action}
+    except Exception as e:
+        logger.error(f"Error processing extension command: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
 @app.post("/api/chrome/register")
 async def register_chrome_extension(request: Request):
     """Chrome Extension の登録エンドポイント"""


### PR DESCRIPTION
## Summary
- allow Chrome extension server URL override via storage or environment
- expose `/api/chrome/extension` on the MCP server
- retry extension history refresh requests
- provide `refreshHistory` in history bridge and call from frontend
- document remote usage setup for the extension

## Testing
- `python -m py_compile mcp-server/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684b67fdc4888327af807b7f43733c0a